### PR TITLE
fix(terminal-ctrl-z): fix misspelling

### DIFF
--- a/gnome-macos-phrases/terminal-ctrl-z.txt
+++ b/gnome-macos-phrases/terminal-ctrl-z.txt
@@ -1,1 +1,1 @@
-<ctrl>+x
+<ctrl>+z


### PR DESCRIPTION
fix misspelling of `<ctrl>+z`.