### PR TITLE
Add superkey remap to uninstall

### DIFF
--- a/bin/uninstall-dconf.sh
+++ b/bin/uninstall-dconf.sh
@@ -54,3 +54,5 @@ gsettings reset org.gnome.Terminal.Legacy.Keybindings:/org/gnome/terminal/legacy
 
 # Revert Left Super Overlay Shortcut
 gsettings reset org.gnome.mutter overlay-key
+
+gsettings reset org.gnome.desktop.input-sources xkb-options 


### PR DESCRIPTION
Recently was considering using, and then changed my mind.  Found that the super key didn't remap as I expected on uninstall but its command appears to have fixed that.