### PR TITLE
https://github.com/petrstepanov/gnome-macos-remap/issues/25

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ chmod +x ./install.sh ./uninstall.sh
 ## Postinstall notes
 * To get a functionality similar to the macOS Spotlight, I recommend installing the [Ulauncher application](https://ulauncher.io/). You can assign the `⌘ space` hotkey for the Ulauncher in its settings.
 * To replicate the emoji selector in macOS, there are at least two options:
-** Smile emoji selector for Linux is a great alternative. Install [here](https://flathub.org/apps/details/it.mijorus.smile). Assign macOS-like keyboard combination `ctrl ⌘ space` via custom keyboard shortcuts in GNOME settings.
-** Emote is another option. Install via `snap` [here](https://snapcraft.io/emote), or via other means detailed in the official repo [here](https://github.com/tom-james-watson/Emote). After installation, you can assign a macOS-like keyboard combination `ctrl ⌘ space` by opening the application, clicking on the hamburger menu ☰, then `Keyboard Shortcuts`.
+- Smile emoji selector for Linux is a great alternative. Install [here](https://flathub.org/apps/details/it.mijorus.smile). Assign macOS-like keyboard combination `ctrl ⌘ space` via custom keyboard shortcuts in GNOME settings.
+- Emote is another option. Install via `snap` [here](https://snapcraft.io/emote), or via other means detailed in the official repo [here](https://github.com/tom-james-watson/Emote). After installation, you can assign a macOS-like keyboard combination `ctrl ⌘ space` by opening the application, clicking on the hamburger menu ☰, then `Keyboard Shortcuts`.
 * Current implementation requires re-installing the script after each kernel update.
 * Logitech MX series keyboard users please [use Solaar to set your keyboard to use macOS layout](https://github.com/petrstepanov/gnome-macos-remap/issues/12).
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ chmod +x ./install.sh ./uninstall.sh
 ## Postinstall notes
 * To get a functionality similar to the macOS Spotlight, I recommend installing the [Ulauncher application](https://ulauncher.io/). You can assign the `⌘ space` hotkey for the Ulauncher in its settings.
 * To replicate the emoji selector in macOS, there are at least two options:
-- Smile emoji selector for Linux is a great alternative. Install [here](https://flathub.org/apps/details/it.mijorus.smile). Assign macOS-like keyboard combination `ctrl ⌘ space` via custom keyboard shortcuts in GNOME settings.
-- Emote is another option. Install via `snap` [here](https://snapcraft.io/emote), or via other means detailed in the official repo [here](https://github.com/tom-james-watson/Emote). After installation, you can assign a macOS-like keyboard combination `ctrl ⌘ space` by opening the application, clicking on the hamburger menu ☰, then `Keyboard Shortcuts`.
+    * Smile emoji selector for Linux is a great alternative. Install [here](https://flathub.org/apps/details/it.mijorus.smile). Assign macOS-like keyboard combination `ctrl ⌘ space` via custom keyboard shortcuts in GNOME settings.
+    * Emote is another option. Install via `snap` [here](https://snapcraft.io/emote), or via other means detailed in the official repo [here](https://github.com/tom-james-watson/Emote). After installation, you can assign a macOS-like keyboard combination `ctrl ⌘ space` by opening the application, clicking on the hamburger menu ☰, then `Keyboard Shortcuts`.
 * Current implementation requires re-installing the script after each kernel update.
 * Logitech MX series keyboard users please [use Solaar to set your keyboard to use macOS layout](https://github.com/petrstepanov/gnome-macos-remap/issues/12).
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ chmod +x ./install.sh ./uninstall.sh
 
 ## Postinstall notes
 * To get a functionality similar to the macOS Spotlight, I recommend installing the [Ulauncher application](https://ulauncher.io/). You can assign the `⌘ space` hotkey for the Ulauncher in its settings.
-* Smile emoji selector for Linux is a great alternative. Install [here](https://flathub.org/apps/details/it.mijorus.smile). Assign macOS-like keyboard combination `ctrl ⌘ space` via custom keyboard shortcuts in GNOME settings.
+* To replicate the emoji selector in macOS, there are at least two options:
+** Smile emoji selector for Linux is a great alternative. Install [here](https://flathub.org/apps/details/it.mijorus.smile). Assign macOS-like keyboard combination `ctrl ⌘ space` via custom keyboard shortcuts in GNOME settings.
+** Emote is another option. Install via `snap` [here](https://snapcraft.io/emote), or via other means detailed in the official repo [here](https://github.com/tom-james-watson/Emote). After installation, you can assign a macOS-like keyboard combination `ctrl ⌘ space` by opening the application, clicking on the hamburger menu ☰, then `Keyboard Shortcuts`.
 * Current implementation requires re-installing the script after each kernel update.
 * Logitech MX series keyboard users please [use Solaar to set your keyboard to use macOS layout](https://github.com/petrstepanov/gnome-macos-remap/issues/12).
 


### PR DESCRIPTION
Added in details on how to set up `Emote` in the readme. 

I'm using it with my instance of macos-remap like so:
![image](https://user-images.githubusercontent.com/5464404/182210914-b88744ec-8a12-43af-8903-2ceba3d1f0f0.png)
Seems to work without issue or concern 😀


This is in reference to issue https://github.com/petrstepanov/gnome-macos-remap/issues/25