### PR TITLE
Add check in install script to ensure display is X11

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Check that display is Xorg, and not Wayland. It won't work properly with Wayland
+[ -n "$WAYLAND_DISPLAY" ] && echo "Please switch to X11. Wayland is not supported." && exit 1
+
 # Install autokey phrases and scripts
 bash ./bin/install-autokey.sh "$1"
 


### PR DESCRIPTION
Things like ctrl+c in terminal don't work in Wayland. This adds a check in install.sh to first ensure the installer is not on Wayland.

From the [Wayland docs](https://docs.fedoraproject.org/en-US/fedora/latest/system-administrators-guide/Wayland/#_determining_whether_you_are_using_wayland), we can check the $WAYLAND_DISPLAY variable to see if Wayland is being used.

### Testing
On a fresh Ubuntu install (defaulted as Wayland):
```
daniel@daniel-MacBookPro:~/gnome-macos-remap$ echo $WAYLAND_DISPLAY
wayland-0

daniel@daniel-MacBookPro:~/gnome-macos-remap$ ./install.sh 
Please switch to X11. Wayland is not supported.
daniel@daniel-MacBookPro:~/gnome-macos-remap$ 
```

After switching to X11
```
daniel@daniel-MacBookPro:~/gnome-macos-remap$ echo $WAYLAND_DISPLAY


daniel@daniel-MacBookPro:~/gnome-macos-remap$ ./install.sh 
Copying AutoKey Phrases...
Please select your "Command+Backspace" functionality.
1) Nautilus - Delete resource
2) Text editing - Delete line
Answer 1 or 2: 2
rm: cannot remove '/home/daniel/.config/autokey/data/gnome-macos-phrases/nautilus-delete.json': No such file or directory
Flipping Super and Control keys...
Changing default GNOME keybindings...
Detected GNOME version 42

Almost there! Please do following:
1. Open 'autokey-gtk'. Go to Edit -> Preferences.
   Select 'Automatically start AutoKey at login'.
2. Restart your computer.
3. On the login screen click the gear icon on the bottom right.
   Select 'GNOME on Xorg'. Login.
4. Enjoy!
```